### PR TITLE
changed repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/medusajs/medusa",
-    "directory": "packages/medusa-plugin-strapi"
+    "url": "https://github.com/Deathwish98/medusa-plugin-strapi"
   },
   "author": "Pawan Sharma",
   "license": "MIT",


### PR DESCRIPTION
Hi @Deathwish98 !

This PR changes the URL of the plugin to this GitHub repo rather than Medusa's github repo. Would be great if you can merge it and publish a new version of the plugin to ensure it's updated on NPM.